### PR TITLE
don't allow undefined items in items list

### DIFF
--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -185,7 +185,7 @@ MdChipsCtrl.prototype.appendChip = function(newChip) {
   if (this.useMdOnAppend && this.mdOnAppend) {
     newChip = this.mdOnAppend({'$chip': newChip});
   }
-  this.items.push(newChip);
+  if(newChip!==undefined) this.items.push(newChip);
 };
 
 /**


### PR DESCRIPTION
There is no easy way to eliminate invalid chips before they're added.
This feature gives the option to filter unwanted items on md-on-append by returning undefined.
